### PR TITLE
Fix Server Crash because Method is only present on clients. (only 1.16)

### DIFF
--- a/src/main/java/com/talhanation/smallships/entities/AbstractCannonShip.java
+++ b/src/main/java/com/talhanation/smallships/entities/AbstractCannonShip.java
@@ -178,7 +178,7 @@ public abstract class AbstractCannonShip extends AbstractShipDamage{
     }
 
     public Vector3d getShootVector(){
-        Vector3d forward = this.getForward().normalize();
+        Vector3d forward = Vector3d.directionFromRotation(this.getRotationVector()).normalize();
         Vector3d VecRight = forward.yRot(-3.14F/2).normalize();
         Vector3d VecLeft  = forward.yRot(3.14F/2).normalize();
 
@@ -203,7 +203,7 @@ public abstract class AbstractCannonShip extends AbstractShipDamage{
 
     public void shootCannons() {
         Vector3d shootVector = this.getShootVector();
-        Vector3d forward = this.getForward();
+        Vector3d forward = Vector3d.directionFromRotation(this.getRotationVector());
 
         Vector3d VecRight = forward.yRot(-3.14F/2).normalize();
         Vector3d VecLeft  = forward.yRot(3.14F/2).normalize();


### PR DESCRIPTION
In 1.16 the Method `Entity.getForward()` is only present in clients and not on the server side)
This PR fixes the issue by instead using `Vector3d.directionFromRotation(this.getRotationVector())` which is what Entity.getForward() is calling itself


I used my wrong git settings, so commit isn't signed correctly on GitHub.