### PR TITLE
[1.21.1] Verify Boat.Type enum entry names do not have invalid path characters before registration

### DIFF
--- a/common/src/main/java/com/talhanation/smallships/world/item/ModItems.java
+++ b/common/src/main/java/com/talhanation/smallships/world/item/ModItems.java
@@ -26,10 +26,11 @@ public class ModItems {
     static {
         Boat.Type[] boatTypes = Boat.Type.values();
         for (Boat.Type type : boatTypes) {
-            COG_ITEMS.put(type, getItem(type.getName() + "_" + CogEntity.ID));
-            BRIGG_ITEMS.put(type, getItem(type.getName() + "_" + BriggEntity.ID));
-            GALLEY_ITEMS.put(type, getItem(type.getName() + "_" + GalleyEntity.ID));
-            DRAKKAR_ITEMS.put(type, getItem(type.getName() + "_" + DrakkarEntity.ID));
+            String name = type.getName().replaceAll("[^a-z0-9_.-]", "_");
+            COG_ITEMS.put(type, getItem(name + "_" + CogEntity.ID));
+            BRIGG_ITEMS.put(type, getItem(name + "_" + BriggEntity.ID));
+            GALLEY_ITEMS.put(type, getItem(name + "_" + GalleyEntity.ID));
+            DRAKKAR_ITEMS.put(type, getItem(name + "_" + DrakkarEntity.ID));
         }
     }
 

--- a/fabric/src/main/java/com/talhanation/smallships/world/item/fabric/ModItemsImpl.java
+++ b/fabric/src/main/java/com/talhanation/smallships/world/item/fabric/ModItemsImpl.java
@@ -76,11 +76,11 @@ public class ModItemsImpl {
         register("cannon_ball", new CannonBallItem((new Item.Properties()).stacksTo(16)));
 
         for (Boat.Type type: Boat.Type.values()) {
-
-            register(type.getName() + "_" + CogEntity.ID,  new CogItem(type, new Item.Properties().stacksTo(1)));
-            register(type.getName() + "_" + BriggEntity.ID,  new BriggItem(type, new Item.Properties().stacksTo(1)));
-            register(type.getName() + "_" + GalleyEntity.ID,  new GalleyItem(type, new Item.Properties().stacksTo(1)));
-			register(type.getName() + "_" + DrakkarEntity.ID,  new DrakkarItem(type, new Item.Properties().stacksTo(1)));
+            String name = type.getName().replaceAll("[^a-z0-9_.-]", "_");
+            register(name + "_" + CogEntity.ID,  new CogItem(type, new Item.Properties().stacksTo(1)));
+            register(name + "_" + BriggEntity.ID,  new BriggItem(type, new Item.Properties().stacksTo(1)));
+            register(name + "_" + GalleyEntity.ID,  new GalleyItem(type, new Item.Properties().stacksTo(1)));
+			register(name + "_" + DrakkarEntity.ID,  new DrakkarItem(type, new Item.Properties().stacksTo(1)));
 
         }
     }

--- a/forge/src/main/java/com/talhanation/smallships/world/item/forge/ModItemsImpl.java
+++ b/forge/src/main/java/com/talhanation/smallships/world/item/forge/ModItemsImpl.java
@@ -42,10 +42,11 @@ public class ModItemsImpl {
         register("cannon_ball", () -> new CannonBallItem((new Item.Properties()).stacksTo(16)));
 
         for (Boat.Type type: Boat.Type.values()) {
-            register(type.getName() + "_" + CogEntity.ID,  () -> new CogItem(type, new Item.Properties().stacksTo(1)));
-            register(type.getName() + "_" + BriggEntity.ID,  () -> new BriggItem(type, new Item.Properties().stacksTo(1)));
-            register(type.getName() + "_" + GalleyEntity.ID,  () -> new GalleyItem(type, new Item.Properties().stacksTo(1)));
-            register(type.getName() + "_" + DrakkarEntity.ID,  () -> new DrakkarItem(type, new Item.Properties().stacksTo(1)));
+            String name = type.getName().replaceAll("[^a-z0-9_.-]", "_");
+            register(name + "_" + CogEntity.ID,  () -> new CogItem(type, new Item.Properties().stacksTo(1)));
+            register(name + "_" + BriggEntity.ID,  () -> new BriggItem(type, new Item.Properties().stacksTo(1)));
+            register(name + "_" + GalleyEntity.ID,  () -> new GalleyItem(type, new Item.Properties().stacksTo(1)));
+            register(name + "_" + DrakkarEntity.ID,  () -> new DrakkarItem(type, new Item.Properties().stacksTo(1)));
         }
     }
 

--- a/neoforge/src/main/java/com/talhanation/smallships/world/item/neoforge/ModItemsImpl.java
+++ b/neoforge/src/main/java/com/talhanation/smallships/world/item/neoforge/ModItemsImpl.java
@@ -41,10 +41,11 @@ public class ModItemsImpl {
         register("cannon_ball", () -> new CannonBallItem((new Item.Properties()).stacksTo(16)));
 
         for (Boat.Type type: Boat.Type.values()) {
-            register(type.getName() + "_" + CogEntity.ID,  () -> new CogItem(type, new Item.Properties().stacksTo(1)));
-            register(type.getName() + "_" + BriggEntity.ID,  () -> new BriggItem(type, new Item.Properties().stacksTo(1)));
-            register(type.getName() + "_" + GalleyEntity.ID,  () -> new GalleyItem(type, new Item.Properties().stacksTo(1)));
-            register(type.getName() + "_" + DrakkarEntity.ID,  () -> new DrakkarItem(type, new Item.Properties().stacksTo(1)));
+            String name = type.getName().replaceAll("[^a-z0-9_.-]", "_");
+            register(name + "_" + CogEntity.ID,  () -> new CogItem(type, new Item.Properties().stacksTo(1)));
+            register(name + "_" + BriggEntity.ID,  () -> new BriggItem(type, new Item.Properties().stacksTo(1)));
+            register(name + "_" + GalleyEntity.ID,  () -> new GalleyItem(type, new Item.Properties().stacksTo(1)));
+            register(name + "_" + DrakkarEntity.ID,  () -> new DrakkarItem(type, new Item.Properties().stacksTo(1)));
         }
     }
 


### PR DESCRIPTION
This resolves an issue where Small Ships will crash with any mods that utilize NeoForge's enum extension system to add new entries to the Boat.Type enum. Most of the information about this is already detailed in some other places:
- https://github.com/The-Aether-Team/Cumulus/issues/22#issuecomment-2484083102
- https://discord.com/channels/903372103888289812/1308179480937889884

(The issue as far as I know is only relevant to NeoForge, but for safety and consistency the enum name check has been added to other item registries).

closes #28